### PR TITLE
feat(db): setup docker-compose for pg

### DIFF
--- a/apps/api-server/README.md
+++ b/apps/api-server/README.md
@@ -1,0 +1,9 @@
+some general instructions on how to get the api server up and running
+
+1- make sure you have docker running (if you haven't installed it, please do that first)
+2- run `cd ~/jade-jasmine/apps/api-server` to move to the api-server path
+3- run `npm install`
+4- copy sample.env to .env if you don't have your own .env
+5- modify the values relevant to you (the SESSION_SECRET for eg or the PGPASSWORD)
+6- run `npm run dev` to start the postgreSQL service and the server
+7- a message should show up about the server listening on the port (you can now naviate to `http://localhost:<port>` and it should produce some json)

--- a/apps/api-server/docker-compose.yml
+++ b/apps/api-server/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  db:
+    image: postgres:alpine3.23
+    container_name: jade-jasmine-postgres    
+    env_file:
+      - ./.env
+    environment:
+      POSTGRES_USER: ${PGUSER}
+      POSTGRES_PASSWORD: ${PGPASSWORD}
+      POSTGRES_DB: ${PGDATABASE}
+    ports:
+      - "${PGPORT}:${PGPORT}"
+    volumes:
+      - pgdata:/var/lib/postgresql/data   
+    networks:
+      - jade_jasmine_net   # join the network
+
+
+volumes:
+  pgdata:
+   
+networks:
+  jade_jasmine_net:
+    name: jade_jasmine_net
+

--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -6,7 +6,12 @@
   "scripts": {
     "start": "node --watch src/index.js",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "db:start": "docker compose -f ./docker-compose.yml up -d",
+    "db:stop": "docker compose -f ./docker-compose.yml down",
+    "db:logs": "docker compose -f ./docker-compose.yml logs -f db",
+    "db:shell": "bash -c 'source .env && docker compose exec db psql -U $PGUSER -d $PGDATABASE'",
+    "dev": "npm run db:start && npm start"
   },
   "keywords": [
     "Node",

--- a/apps/api-server/sample.env
+++ b/apps/api-server/sample.env
@@ -4,3 +4,21 @@ PORT=3003
 # when you first run `npm start` it will complain that SESSION_SECRET is missing and give you a generated random value for it
 # use that value to define your real SESSION_SECRET in .env and then retry the start command
 SESSION_SECRET=verylongsessionsecretalphanumericvaluewhichisgeneratedforyou
+
+# add this postgreSQL userid to your .env
+PGUSER="jadeuser"
+
+# add the password we discussed for postgreSQL here
+PGPASSWORD="password"
+
+# do not change the name of the db though
+PGDATABASE="foodfinderdb"
+
+# this port should work as is
+PGPORT="5432"
+
+# do not change this
+NODE_ENV="development"
+
+# do not change this if you're working locally
+PG_HOST="localhost"


### PR DESCRIPTION
updated the sample.env as the new fields are needed to start postgres in docker
added a new readme at the api-server level to help the front-end team start the server
added a new docker-compose.yml file to setup and start the db in a docker volume under a custom network name

closes #13