### PR TITLE
chore: clean up the extraneous package-lock.json files and centralise them at root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ pnpm-debug.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.next


### PR DESCRIPTION
I've transferred the api-server .gitignore file to the ignore file at the root level.

I have also remove package-lock files within the apps and added the apps directory in the workspaces.

When you work on this repo, you now just need to run `npm install` at the root level. 