### PR TITLE
chore(eslint): rm console.log warning from api-server

### DIFF
--- a/apps/api-server/eslint.config.js
+++ b/apps/api-server/eslint.config.js
@@ -18,7 +18,7 @@ export default [
     },
     rules: {
       // 3. Add backend-specific preferences
-      "no-console": "warn",        // Good for servers to avoid cluttering logs
+      "no-console": "off",        // servers need debug logs
       "no-unused-vars": "error",   // Keeps your API clean
       "prefer-const": "error",     // Encourages immutable data patterns
     },


### PR DESCRIPTION
the no-console rule should not be applied to node server projects. The logs are the only way we have to debug (both in production and in development)
closes #25 