### PR TITLE
feat(client): Add partner login and registration buttons to Navbar

### DIFF
--- a/apps/client/foodbank-finder/src/components/MobileMenu.astro
+++ b/apps/client/foodbank-finder/src/components/MobileMenu.astro
@@ -9,7 +9,7 @@ const managerUrl =
   <ul>
     <li><a href="/">Home</a></li>
     <li><a href="#"><BsSearch />Search</a></li>
-    <li><a href={managerUrl}>Partner</a></li>
+    <li><a href={managerUrl}>Login</a></li>
     <li><a href=`${managerUrl}/signup`>Register</a></li>
   </ul>
   <button class="menu-close-button"><BsX /></button>

--- a/apps/client/foodbank-finder/src/components/MobileMenu.astro
+++ b/apps/client/foodbank-finder/src/components/MobileMenu.astro
@@ -9,8 +9,8 @@ const managerUrl =
   <ul>
     <li><a href="/">Home</a></li>
     <li><a href="#"><BsSearch />Search</a></li>
-    <li><a href={managerUrl}>Partner Login</a></li>
-    <li><a href=`${managerUrl}/signup`>Register Food Bank</a></li>
+    <li><a href={managerUrl}>Partner</a></li>
+    <li><a href=`${managerUrl}/signup`>Register</a></li>
   </ul>
   <button class="menu-close-button"><BsX /></button>
 </aside>

--- a/apps/client/foodbank-finder/src/components/MobileMenu.astro
+++ b/apps/client/foodbank-finder/src/components/MobileMenu.astro
@@ -9,8 +9,10 @@ const managerUrl =
   <ul>
     <li><a href="/">Home</a></li>
     <li><a href="#"><BsSearch />Search</a></li>
-    <li><a href={managerUrl}>Login</a></li>
-    <li><a href=`${managerUrl}/signup`>Register</a></li>
+    <li><a href=`${managerUrl}/login` class="login-btn">Login</a></li>
+    <li>
+      <a href=`${managerUrl}/signup` class="signup-btn">Register</a>
+    </li>
   </ul>
   <button class="menu-close-button"><BsX /></button>
 </aside>

--- a/apps/client/foodbank-finder/src/components/MobileMenu.astro
+++ b/apps/client/foodbank-finder/src/components/MobileMenu.astro
@@ -1,5 +1,7 @@
 ---
 import { BsSearch, BsList, BsX } from "react-icons/bs";
+const managerUrl =
+  import.meta.env.PUBLIC_MANAGER_URL || "http://localhost:3000";
 ---
 
 <button class="menu-open-button"><BsList /></button>
@@ -7,6 +9,8 @@ import { BsSearch, BsList, BsX } from "react-icons/bs";
   <ul>
     <li><a href="/">Home</a></li>
     <li><a href="#"><BsSearch />Search</a></li>
+    <li><a href={managerUrl}>Partner Login</a></li>
+    <li><a href=`${managerUrl}/signup`>Register Food Bank</a></li>
   </ul>
   <button class="menu-close-button"><BsX /></button>
 </aside>

--- a/apps/client/foodbank-finder/src/components/Navbar.astro
+++ b/apps/client/foodbank-finder/src/components/Navbar.astro
@@ -12,9 +12,9 @@ const managerUrl =
   <ul class="nav-links">
     <li><a href="#">Home</a></li>
     <li><a href="#"><BsSearch /> Search for item</a></li>
-    <li><a href=`${managerUrl}` class="login-btn">Partner Login</a></li>
+    <li><a href=`${managerUrl}` class="login-btn">Login</a></li>
     <li>
-      <a href=`${managerUrl}/signup` class="signup-btn">Register Food Bank</a>
+      <a href=`${managerUrl}/signup` class="signup-btn">Register</a>
     </li>
   </ul>
   <div class="mobile-menu-toggle">

--- a/apps/client/foodbank-finder/src/components/Navbar.astro
+++ b/apps/client/foodbank-finder/src/components/Navbar.astro
@@ -12,7 +12,7 @@ const managerUrl =
   <ul class="nav-links">
     <li><a href="#">Home</a></li>
     <li><a href="#"><BsSearch /> Search for item</a></li>
-    <li><a href=`${managerUrl}` class="login-btn">Login</a></li>
+    <li><a href=`${managerUrl}/login` class="login-btn">Login</a></li>
     <li>
       <a href=`${managerUrl}/signup` class="signup-btn">Register</a>
     </li>

--- a/apps/client/foodbank-finder/src/components/Navbar.astro
+++ b/apps/client/foodbank-finder/src/components/Navbar.astro
@@ -1,6 +1,8 @@
 ---
 import { BsSearch } from "react-icons/bs";
 import MobileMenu from "./MobileMenu.astro";
+const managerUrl =
+  import.meta.env.PUBLIC_MANAGER_URL || "http://localhost:3000";
 ---
 
 <nav class="navbar">
@@ -10,6 +12,10 @@ import MobileMenu from "./MobileMenu.astro";
   <ul class="nav-links">
     <li><a href="#">Home</a></li>
     <li><a href="#"><BsSearch /> Search for item</a></li>
+    <li><a href=`${managerUrl}` class="login-btn">Partner Login</a></li>
+    <li>
+      <a href=`${managerUrl}/signup` class="signup-btn">Register Food Bank</a>
+    </li>
   </ul>
   <div class="mobile-menu-toggle">
     <MobileMenu />
@@ -36,13 +42,39 @@ import MobileMenu from "./MobileMenu.astro";
     display: none;
     list-style: none;
     gap: 1.25rem;
+    align-items: center;
   }
   .nav-links a {
     color: #333;
     text-decoration: none;
   }
+  .login-btn {
+    padding: 0.5rem 1rem;
+    border: 1px solid #333;
+    border-radius: 4px;
+    font-weight: 500;
+    transition: background-color 0.2s;
+  }
+  .login-btn:hover {
+    background-color: #f5f5f5;
+  }
+  .signup-btn {
+    padding: 0.5rem 1rem;
+    background-color: #333;
+    color: white !important;
+    border-radius: 4px;
+    font-weight: 500;
+    transition: opacity 0.2s;
+  }
+  .signup-btn:hover {
+    opacity: 0.9;
+  }
   .mobile-menu-toggle {
     display: block;
+  }
+  .signup-btn, .login-btn {
+    white-space: nowrap;
+    text-align: center;
   }
   @media (min-width: 48rem) {
     .nav-links {

--- a/apps/client/foodbank-finder/src/layouts/Layout.astro
+++ b/apps/client/foodbank-finder/src/layouts/Layout.astro
@@ -1,27 +1,31 @@
 ---
 import Navbar from "../components/Navbar.astro";
+import "@fontsource-variable/roboto/index.css";
+import "@fontsource/noto-color-emoji/index.css";
 ---
+
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<link rel="icon" href="/favicon.ico" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro Basics</title>
-	</head>
-	<body>
-		<Navbar />
-		<slot />
-	</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="generator" content={Astro.generator} />
+    <title>Astro Basics</title>
+  </head>
+  <body>
+    <Navbar />
+    <slot />
+  </body>
 </html>
 
 <style>
-	html,
-	body {
-		margin: 0;
-		width: 100%;
-		height: 100%;
-	}
+  html,
+  body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    font-family: "Roboto Variable", "Noto Color Emoji", sans-serif;
+  }
 </style>


### PR DESCRIPTION
### This PR adds "Partner Login" and "Register Food Bank" buttons to the navigation bar in the foodbank-finder app. These buttons redirect users to the foodbank-manager application.

- Add login/register buttons to desktop Navbar component.
- Add corresponding links to MobileMenu for responsive support.
- Configured links to use the PUBLIC_MANAGER_URL environment variable (defaults to localhost:3000).
- Refactored font imports (Roboto and Noto Color Emoji) to Layout.astro to make them globally available.
- Closes #60 

----
This is how it looks! We can change the styling in a future issue.

<img width="640" height="87" alt="image" src="https://github.com/user-attachments/assets/6995b978-aba5-4b4d-88f2-0b6362d21f79" />
